### PR TITLE
Allow QRBuilder to accept bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ use fast_qr::qr::QRBuilder;
 fn main() -> Result<(), ConvertError> {
     // QRBuilder::new can fail if content is too big for version,
     // please check before unwrapping.
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .build()
         .unwrap();
 
@@ -46,7 +46,7 @@ use fast_qr::qr::QRBuilder;
 fn main() -> Result<(), ConvertError> {
     // QRBuilder::new can fail if content is too big for version,
     // please check before unwrapping.
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .build()
         .unwrap();
 
@@ -70,7 +70,7 @@ use fast_qr::qr::QRBuilder;
 fn main() -> Result<(), ConvertError> {
     // QRBuilder::new can fail if content is too big for version,
     // please check before unwrapping.
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .build()
         .unwrap();
 

--- a/benches/qr.rs
+++ b/benches/qr.rs
@@ -48,7 +48,7 @@ fn bench_fastqr_qrcode(c: &mut Criterion) {
 
         group.bench_function("fast_qr", |b| {
             b.iter(|| {
-                QRBuilder::new(black_box("https://example.com/".into()))
+                QRBuilder::new(black_box("https://example.com/"))
                     .ecl(*fast_qr_level)
                     .version(*fast_qr_version)
                     .build()

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -23,7 +23,7 @@ use fast_qr::qr::QRBuilder;
 fn main() -> Result<(), ConvertError> {
     // QRBuilder::new can fail if content is too big for version,
     // please check before unwrapping.
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .build()
         .unwrap();
 
@@ -46,7 +46,7 @@ use fast_qr::qr::QRBuilder;
 fn main() -> Result<(), ConvertError> {
     // QRBuilder::new can fail if content is too big for version,
     // please check before unwrapping.
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .build()
         .unwrap();
 
@@ -70,7 +70,7 @@ use fast_qr::qr::QRBuilder;
 fn main() -> Result<(), ConvertError> {
     // QRBuilder::new can fail if content is too big for version,
     // please check before unwrapping.
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .build()
         .unwrap();
 

--- a/src/convert/image.rs
+++ b/src/convert/image.rs
@@ -8,7 +8,7 @@
 //! # fn main() -> Result<(), ConvertError> {
 //! // QRBuilde::new can fail if content is too big for version,
 //! // please check before unwrapping.
-//! let qrcode = QRBuilder::new("https://example.com/".into())
+//! let qrcode = QRBuilder::new("https://example.com/")
 //!     .build()
 //!     .unwrap();
 //!

--- a/src/convert/svg.rs
+++ b/src/convert/svg.rs
@@ -8,7 +8,7 @@
 //! # fn main() -> Result<(), ConvertError> {
 //! // QRBuilde::new can fail if content is too big for version,
 //! // please check before unwrapping.
-//! let qrcode = QRBuilder::new("https://example.com/".into())
+//! let qrcode = QRBuilder::new("https://example.com/")
 //!     .build()
 //!     .unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! # fn main() -> Result<(), ConvertError> {
 //! // QRBuilder::new can fail if content is too big for version,
 //! // please check before unwrapping.
-//! let qrcode = QRBuilder::new("https://example.com/".into())
+//! let qrcode = QRBuilder::new("https://example.com/")
 //!     .build()
 //!     .unwrap();
 //!
@@ -30,7 +30,7 @@
 //! # fn main() -> Result<(), ConvertError> {
 //! // QRBuilder::new can fail if content is too big for version,
 //! // please check before unwrapping.
-//! let qrcode = QRBuilder::new("https://example.com/".into())
+//! let qrcode = QRBuilder::new("https://example.com/")
 //!     .build()
 //!     .unwrap();
 //!
@@ -53,7 +53,7 @@
 //! # fn main() -> Result<(), ConvertError> {
 //! // QRBuilder::new can fail if content is too big for version,
 //! // please check before unwrapping.
-//! let qrcode = QRBuilder::new("https://example.com/".into())
+//! let qrcode = QRBuilder::new("https://example.com/")
 //!     .build()
 //!     .unwrap();
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use fast_qr::qr::QRBuilder;
 use fast_qr::{Version, ECL};
 
 fn main() {
-    let qrcode = QRBuilder::new("https://example.com/".into())
+    let qrcode = QRBuilder::new("https://example.com/")
         .ecl(ECL::H)
         .version(Version::V03)
         .build()

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -168,7 +168,7 @@ impl QRCode {
 ///     .build();
 /// ```
 pub struct QRBuilder {
-    input: String,
+    input: Vec<u8>,
     ecl: Option<ECL>,
     // mode: Option<Mode>,
     version: Option<Version>,
@@ -178,9 +178,9 @@ pub struct QRBuilder {
 impl QRBuilder {
     /// Creates an instance of `QRBuilder` with default parameters
     #[must_use]
-    pub fn new(input: String) -> QRBuilder {
+    pub fn new<I: Into<Vec<u8>>>(input: I) -> QRBuilder {
         QRBuilder {
-            input,
+            input: input.into(),
             mask: None,
             // mode: None,
             version: None,
@@ -217,6 +217,6 @@ impl QRBuilder {
     /// - `QRCodeError::EncodedData` if `input` is too large to be encoded. See [an online table](https://fast-qr.com/blog/tables/ecl) for more info.
     /// - `QRCodeError::SpecifiedVersion` if specified `version` is too small to contain data
     pub fn build(&self) -> Result<QRCode, QRCodeError> {
-        QRCode::new(self.input.as_bytes(), self.ecl, self.version, self.mask)
+        QRCode::new(&self.input, self.ecl, self.version, self.mask)
     }
 }


### PR DESCRIPTION
QR codes should not be limited to storing only UTF-8 encoded text. Raw bytes are more useful.

Strings and string slices can trivially by converted to a vector of bytes. This is a breaking change, but also a great ergonomic and functionality improvement.