### PR TITLE
Fix #19

### DIFF
--- a/src/convert/svg.rs
+++ b/src/convert/svg.rs
@@ -72,7 +72,7 @@ impl Default for SvgBuilder {
             dot_color: [0, 0, 0, 255],
             margin: 4,
             commands: Vec::new(),
-            command_colors: Vec::new(),
+            command_colors: vec![None, None, None, None],
 
             // Image Embedding
             image: None,


### PR DESCRIPTION
This fixes #19.

## Description

@erwanvivien The issue is [here](https://github.com/erwanvivien/fast_qr/blob/master/src/convert/svg.rs#L75) which is called from [`to_str`](https://github.com/erwanvivien/fast_qr/blob/411d951fc42d3a56454ac61da4dd49b50b1fc9b9/src/convert/svg.rs#L308) because [`command_colors`](https://github.com/erwanvivien/fast_qr/blob/411d951fc42d3a56454ac61da4dd49b50b1fc9b9/src/convert/svg.rs#L75) is initialized to an empty vector instead of a vector of 4 `None`s

I don't know if the fix makes sense as I didn't look into your code too much but it seems to work and all the tests are passing. Adding to that, it would make sense to check for potential similar issues before merging this. I'm going to be offline for a bit but ai think you should be able to add commits to this, otherwise I'll make an update tonight if needed.

## Testing

I added the following to `svg.rs` to test that the fix worked.

```rs
#[cfg(test)]
mod tests {
    use crate::qr::QRBuilder;
    use crate::convert::svg::SvgBuilder;
    #[test]
    fn test() {
        let tmp = SvgBuilder::default();
        let qrcode = QRBuilder::new("https://example.com/")
        .build()
        .unwrap(); 
        tmp.to_str(&qrcode);
    }
}
```

```sh
cargo t -F image,svg -- svg::tests
```

The test was failing with the same error as mentioned in #19 but it passed after the change I made.