### PR TITLE
Remove wee_alloc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ image = ["svg", "dep:resvg"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
-wee_alloc = "0.4"
 
 [profile.release]
 debug = false

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3,9 +3,6 @@ use crate::convert;
 use crate::QRCode;
 use wasm_bindgen::prelude::*;
 
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 fn bool_to_u8(qr: QRCode) -> Vec<u8> {
     let dim = qr.size;
     qr.data[..dim * dim]


### PR DESCRIPTION
`wee_alloc` is no longer maintained and has a few critical open issues (memory leaks), see [here](https://github.com/rustwasm/wee_alloc/issues/107).

```sh
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 511 security advisories (from C:\Users\anton\.cargo\advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (121 crate dependencies)
Crate:     wee_alloc
Version:   0.4.5
Warning:   unmaintained
Title:     wee_alloc is Unmaintained
Date:      2022-05-11
ID:        RUSTSEC-2022-0054
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0054
Dependency tree:
wee_alloc 0.4.5
└── fast_qr 0.8.4
```

This reverts back to the recommended [`dlmalloc-rs`](https://github.com/alexcrichton/dlmalloc-rs).

I ran the `wasm-pack.sh` file and everything seems fine but I have not tested this from JS directly. A few other PRs seem to just remove the extra `wee_alloc` stuff with no other change so this should be fine. I have also not committed any of the changes that happen to the `pkg/*` files when I run `wasm-pack.sh`, should I do that?