### PR TITLE
Use `required-features` example property instead of `compile_error!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,19 @@ harness = false
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[example]]
+name = "custom"
+required-features = ["image"]
+
+[[example]]
+name = "embed"
+required-features = ["image"]
+
+[[example]]
+name = "image"
+required-features = ["image"]
+
+[[example]]
+name = "svg"
+required-features = ["svg"]

--- a/examples/custom.rs
+++ b/examples/custom.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "image", feature = "svg"))]
 fn main() {
     use fast_qr::{
         convert::{image::ImageBuilder, Builder, Shape},
@@ -37,9 +36,4 @@ fn main() {
         .fit_width(600)
         .background_color([255, 255, 255, 255])
         .to_file(&qrcode, "custom.png");
-}
-
-#[cfg(not(feature = "image"))]
-fn main() {
-    compile_error!("Please enable the `image` features.");
 }

--- a/examples/embed.rs
+++ b/examples/embed.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "image", feature = "svg"))]
 fn main() {
     use fast_qr::{
         convert::{image::ImageBuilder, Builder, ImageBackgroundShape, Shape},
@@ -22,9 +21,4 @@ fn main() {
         .image_background_color([165, 34, 247, 255])
         .image_background_shape(ImageBackgroundShape::Square)
         .to_file(&qrcode, "embed.png");
-}
-
-#[cfg(not(feature = "image"))]
-fn main() {
-    compile_error!("Please enable the `image` features.");
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "image")]
 fn main() {
     use fast_qr::{
         convert::{image::ImageBuilder, Builder, Shape},
@@ -23,9 +22,4 @@ fn main() {
         .fit_width(512)
         .background_color([255, 255, 255, 255]) // opaque
         .to_bytes(&qrcode);
-}
-
-#[cfg(not(feature = "image"))]
-fn main() {
-    compile_error!("Please enable the `image` features.");
 }

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "svg")]
 fn main() {
     use fast_qr::{
         convert::{svg::SvgBuilder, Builder, Shape},
@@ -14,9 +13,4 @@ fn main() {
     let _svg = SvgBuilder::default()
         .shape(Shape::RoundedSquare)
         .to_file(&qrcode, "svg.svg");
-}
-
-#[cfg(not(feature = "svg"))]
-fn main() {
-    eprintln!("Please enable the `svg` features.")
 }


### PR DESCRIPTION
This will make cargo enable features needed for the example automatically without the need for checks in teh example via `cfg` directives