### PR TITLE
Implement std::error::Error for ImageError

### DIFF
--- a/src/convert/image.rs
+++ b/src/convert/image.rs
@@ -22,6 +22,8 @@
 //! # }
 //! ```
 
+use std::error::Error;
+use std::fmt::{Formatter, Write};
 use std::io;
 
 use crate::QRCode;
@@ -50,6 +52,18 @@ pub enum ImageError {
     ImageError(String),
     /// Error while convert to bytes
     EncodingError(String),
+}
+
+impl std::error::Error for ImageError {}
+
+impl std::fmt::Display for ImageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImageError::IoError(io_err) => f.write_str(io_err.to_string().as_str()),
+            ImageError::ImageError(error) => f.write_str(error.as_str()),
+            ImageError::EncodingError(error) => f.write_str(error.as_str())
+        }
+    }
 }
 
 /// Creates an ImageBuilder instance, which contains an [`SvgBuilder`]


### PR DESCRIPTION
Implement the `std::error::Error` trait for `ImageError` to enable easy error handling;

```rust
fn gen_qr_code(input: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
    let qr = QRBuilder::new(input).build()?;

    let img = ImageBuilder::default()
        .shape(Shape::RoundedSquare)
        .background_color([255, 255, 255, 0])
        .fit_width(600)
        .to_bytes(&qr)?;

     Ok(img)
}
```