### PR TITLE
fix: fix diagonal inversion of qr code when rendering to svg and image

### DIFF
--- a/src/convert/svg.rs
+++ b/src/convert/svg.rs
@@ -268,9 +268,9 @@ impl SvgBuilder {
             path.push_str(r#"<path d=""#);
         }
 
-        for y in 0..qr.size {
-            let line = &qr[y];
-            for (x, &cell) in line.iter().enumerate() {
+        for x in 0..qr.size {
+            let line = &qr[x];
+            for (y, &cell) in line.iter().enumerate() {
                 if !cell.value() {
                     continue;
                 }


### PR DESCRIPTION
Fixes https://github.com/erwanvivien/fast_qr/issues/47

Using the following `QRCode`:
```rust
    let qrcode = QRBuilder::new("Test")
        .ecl(ECL::M)
        .version(Version::V01)
        .build()
        .unwrap();
```

The output is not diagonally inverted, and the format string is correct:

![rendered_as_image_fixed](https://github.com/erwanvivien/fast_qr/assets/25519273/e1ad364b-85af-4cab-80e3-531e2608b211)

