### PR TITLE
Feature: image margins

### DIFF
--- a/pkg/fast_qr.d.ts
+++ b/pkg/fast_qr.d.ts
@@ -66,10 +66,10 @@ export class SvgOptions {
   free(): void;
 /**
 * Updates the shape of the QRCode modules.
-* @param {number} shape
+* @param {Shape} shape
 * @returns {SvgOptions}
 */
-  shape(shape: number): SvgOptions;
+  shape(shape: Shape): SvgOptions;
 /**
 * Updates the module color of the QRCode. Tales a string in the format `#RRGGBB[AA]`.
 * @param {string} module_color
@@ -102,10 +102,10 @@ export class SvgOptions {
   image_background_color(image_background_color: string): SvgOptions;
 /**
 * Updates the shape of the image background. Takes an convert::ImageBackgroundShape.
-* @param {number} image_background_shape
+* @param {ImageBackgroundShape} image_background_shape
 * @returns {SvgOptions}
 */
-  image_background_shape(image_background_shape: number): SvgOptions;
+  image_background_shape(image_background_shape: ImageBackgroundShape): SvgOptions;
 /**
 * Updates the size of the image. Takes a size and a gap (unit being module size).
 * @param {number} size
@@ -128,6 +128,7 @@ export class SvgOptions {
 export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 export interface InitOutput {
+  readonly memory: WebAssembly.Memory;
   readonly qr: (a: number, b: number, c: number) => void;
   readonly __wbg_svgoptions_free: (a: number) => void;
   readonly svgoptions_shape: (a: number, b: number) => number;
@@ -141,13 +142,10 @@ export interface InitOutput {
   readonly svgoptions_image_position: (a: number, b: number, c: number) => number;
   readonly svgoptions_new: () => number;
   readonly qr_svg: (a: number, b: number, c: number, d: number) => void;
-  readonly memory: WebAssembly.Memory;
   readonly __wbindgen_add_to_stack_pointer: (a: number) => number;
   readonly __wbindgen_malloc: (a: number, b: number) => number;
   readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
   readonly __wbindgen_free: (a: number, b: number, c: number) => void;
-  readonly __wbindgen_thread_destroy: (a: number, b: number) => void;
-  readonly __wbindgen_start: () => void;
 }
 
 export type SyncInitInput = BufferSource | WebAssembly.Module;
@@ -156,19 +154,17 @@ export type SyncInitInput = BufferSource | WebAssembly.Module;
 * a precompiled `WebAssembly.Module`.
 *
 * @param {SyncInitInput} module
-* @param {WebAssembly.Memory} maybe_memory
 *
 * @returns {InitOutput}
 */
-export function initSync(module: SyncInitInput, maybe_memory?: WebAssembly.Memory): InitOutput;
+export function initSync(module: SyncInitInput): InitOutput;
 
 /**
 * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
 * for everything else, calls `WebAssembly.instantiate` directly.
 *
 * @param {InitInput | Promise<InitInput>} module_or_path
-* @param {WebAssembly.Memory} maybe_memory
 *
 * @returns {Promise<InitOutput>}
 */
-export default function __wbg_init (module_or_path?: InitInput | Promise<InitInput>, maybe_memory?: WebAssembly.Memory): Promise<InitOutput>;
+export default function __wbg_init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/pkg/fast_qr_bg.wasm.d.ts
+++ b/pkg/fast_qr_bg.wasm.d.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+export const memory: WebAssembly.Memory;
 export function qr(a: number, b: number, c: number): void;
 export function __wbg_svgoptions_free(a: number): void;
 export function svgoptions_shape(a: number, b: number): number;
@@ -13,10 +14,7 @@ export function svgoptions_image_size(a: number, b: number, c: number): number;
 export function svgoptions_image_position(a: number, b: number, c: number): number;
 export function svgoptions_new(): number;
 export function qr_svg(a: number, b: number, c: number, d: number): void;
-export const memory: WebAssembly.Memory;
 export function __wbindgen_add_to_stack_pointer(a: number): number;
 export function __wbindgen_malloc(a: number, b: number): number;
 export function __wbindgen_realloc(a: number, b: number, c: number, d: number): number;
 export function __wbindgen_free(a: number, b: number, c: number): void;
-export function __wbindgen_thread_destroy(a: number, b: number): void;
-export function __wbindgen_start(): void;

--- a/src/convert/image.rs
+++ b/src/convert/image.rs
@@ -117,8 +117,13 @@ impl Builder for ImageBuilder {
         self
     }
 
-    fn image_size(&mut self, image_size: f64, gap: f64) -> &mut Self {
-        self.svg_builder.image_size(image_size, gap);
+    fn image_size(&mut self, image_size: f64) -> &mut Self {
+        self.svg_builder.image_size(image_size);
+        self
+    }
+
+    fn image_gap(&mut self, gap: f64) -> &mut Self {
+        self.svg_builder.image_gap(gap);
         self
     }
 

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -337,7 +337,9 @@ pub trait Builder {
         -> &mut Self;
     /// Updates the image size and the gap between the image and the [`crate::QRCode`]
     /// Default is around 30% of the [`crate::QRCode`] size
-    fn image_size(&mut self, image_size: f64, gap: f64) -> &mut Self;
+    fn image_size(&mut self, image_size: f64) -> &mut Self;
+    /// Updates the gap between the image and the [`crate::QRCode`]
+    fn image_gap(&mut self, gap: f64) -> &mut Self;
     /// Updates the image position, anchor is the center of the image. Default is the center of the [`crate::QRCode`]
     fn image_position(&mut self, x: f64, y: f64) -> &mut Self;
 }

--- a/src/convert/svg.rs
+++ b/src/convert/svg.rs
@@ -49,7 +49,8 @@ pub struct SvgBuilder {
     /// Background shape for the image, default is square
     image_background_shape: ImageBackgroundShape,
     /// Size of the image, default is ~1/3 of the svg
-    image_size: Option<(f64, f64)>,
+    image_size: Option<f64>,
+    image_gap: Option<f64>,
     /// Position of the image, default is center
     image_position: Option<(f64, f64)>,
 }
@@ -79,6 +80,7 @@ impl Default for SvgBuilder {
             image_background_color: [255; 4].into(),
             image_background_shape: ImageBackgroundShape::Square,
             image_size: None,
+            image_gap: None,
             image_position: None,
         }
     }
@@ -130,8 +132,13 @@ impl Builder for SvgBuilder {
         self
     }
 
-    fn image_size(&mut self, image_size: f64, gap: f64) -> &mut Self {
-        self.image_size = Some((image_size, gap));
+    fn image_size(&mut self, image_size: f64) -> &mut Self {
+        self.image_size = Some(image_size);
+        self
+    }
+
+    fn image_gap(&mut self, gap: f64) -> &mut Self {
+        self.image_gap = Some(gap);
         self
     }
 
@@ -196,7 +203,15 @@ impl SvgBuilder {
         let (mut border_size, mut placed_coord, mut image_size) =
             Self::image_placement(self.image_background_shape, self.margin, n);
 
-        if let Some((override_size, gap)) = self.image_size {
+        if let Some(gap) = self.image_gap {
+            border_size = gap * 2f64;
+            let mut placed_coord_x = (self.margin * 2 + n) as f64 - border_size;
+            placed_coord_x /= 2f64;
+            placed_coord = (placed_coord_x, placed_coord_x);
+        }
+
+        if let Some(override_size) = self.image_size {
+            let gap = self.image_gap.unwrap_or(0f64);
             border_size = override_size + gap * 2f64;
             let mut placed_coord_x = (self.margin * 2 + n) as f64 - border_size;
             placed_coord_x /= 2f64;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -187,7 +187,8 @@ pub fn qr_svg(content: &str, options: SvgOptions) -> String {
     if options.image_size.len() == 2 {
         let size = options.image_size[0];
         let gap = options.image_size[1];
-        builder.image_size(size, gap);
+        builder.image_size(size);
+        builder.image_gap(gap);
     }
 
     if options.image_size.len() == 2 {


### PR DESCRIPTION
Our users want the ability to add a margin to the embedded image in QR codes. 

Added `Build::image_gap` and changed the argument of `Builder::image_size` to remove the gap argument so it can be supplied separately.