### PR TITLE
feat: add smol_png module for compact PNG generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ version = "0.13.1"
 dependencies = [
  "base64",
  "criterion",
+ "js-sys",
  "qrcode",
  "resvg",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 resvg = { version = "0.45.1", optional = true }
 
-
 [features]
 svg = []
 image = ["svg", "dep:resvg"]
 wasm-bindgen = ["dep:wasm-bindgen"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
 wasm-bindgen = { version = "0.2", optional = true }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ npm install --save fast_qr
 yarn add fast_qr
 ```
 
-### Create an svg
+### Create an svg or compact png
 
 ```js
-/// Once `init` is called, `qr_svg` can be called any number of times
-import init, { qr_svg, SvgOptions, Shape } from '/pkg/fast_qr.js'
+/// Once `init` is called, `qr_svg` and `qr_smol_image` can be called any number of times
+import init, { qr_smol_image, qr_svg, SvgOptions, Shape } from '/pkg/fast_qr.js'
 
 const options = new SvgOptions()
   .margin(4)
@@ -134,6 +134,12 @@ await init();
 for (let i = 0; i < 10; i++) {
   const svg = qr_svg("https://fast-qr.com", options);
   console.log(svg);
+
+  const smol = qr_smol_image(
+    "https://fast-qr.com",
+    { scale: 4, quietZone: 4 },
+  );
+  console.log(smol); // Uint8Array containing a tiny black and white PNG
 }
 ```
 
@@ -159,6 +165,26 @@ wasm-pack pack pkg # Creates an archive of said package
 # wasm-pack publish pkg # Creates an archive & publish it to npm
 ```
 
+### Why the default JS builds exclude full image rendering
+
+The Rust `image` feature uses `resvg` to rasterize SVG into PNG. That works well for native Rust usage, but it is intentionally excluded from the default wasm and Node.js builds in this repo.
+
+The reason is bundle size: including the full image stack makes the wasm artifact dramatically larger, while `qr_smol_image` already covers the common JS use case of generating a compact PNG from QR modules.
+
+Measured in this repo:
+
+- `wasm-bindgen` only (`qr` + `qr_smol_image`): about `68 KB` final wasm output
+- `svg + wasm-bindgen` (`qr_svg` included): about `133 KB` final wasm output
+- `image + wasm-bindgen` (`resvg` included): about `2.3 MB` final wasm output
+
+So the default JS-facing builds keep:
+
+- `qr`
+- `qr_svg`
+- `qr_smol_image`
+
+And leave the full `image` / `resvg` path for native Rust-only usage, where the binary size tradeoff makes more sense.
+
 ## Benchmarks
 
 According to the following benchmarks, `fast_qr` is approximately 6-7x faster than `qrcode`.
@@ -173,3 +199,10 @@ According to the following benchmarks, `fast_qr` is approximately 6-7x faster th
 | V40H/fast_qr | 2.4313 ms | 2.4362 ms | 2.4411 ms | fast_qr is 7.40x faster |
 
 More benchmarks can be found in [/benches folder](https://github.com/erwanvivien/fast_qr/tree/master/benches).
+
+For wasm and JS benchmarking in Node, rebuild the package and run:
+
+```bash
+./wasm-pack.sh
+node benches/node.mjs
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ mod polynomials;
 #[macro_use]
 pub mod qr;
 mod score;
+mod smol_png;
 mod version;
 
 #[cfg(test)]

--- a/src/smol_png.rs
+++ b/src/smol_png.rs
@@ -1,0 +1,274 @@
+use crate::QRCode;
+
+const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
+const fn make_crc32_table() -> [u32; 256] {
+    let mut table = [0u32; 256];
+    let mut i = 0;
+
+    while i < 256 {
+        let mut crc = i as u32;
+        let mut j = 0;
+
+        while j < 8 {
+            if (crc & 1) != 0 {
+                crc = (crc >> 1) ^ 0xEDB8_8320;
+            } else {
+                crc >>= 1;
+            }
+            j += 1;
+        }
+
+        table[i] = crc;
+        i += 1;
+    }
+
+    table
+}
+
+const CRC32_TABLE: [u32; 256] = make_crc32_table();
+
+fn crc32_update(mut crc: u32, bytes: &[u8]) -> u32 {
+    for &byte in bytes {
+        let idx = ((crc ^ u32::from(byte)) & 0xFF) as usize;
+        crc = (crc >> 8) ^ CRC32_TABLE[idx];
+    }
+    crc
+}
+
+fn adler32(bytes: &[u8]) -> u32 {
+    const MOD_ADLER: u32 = 65_521;
+    let mut a = 1u32;
+    let mut b = 0u32;
+
+    for chunk in bytes.chunks(5_552) {
+        for &byte in chunk {
+            a = (a + u32::from(byte)) % MOD_ADLER;
+            b = (b + a) % MOD_ADLER;
+        }
+    }
+
+    (b << 16) | a
+}
+
+fn append_u32_be(output: &mut Vec<u8>, value: u32) {
+    output.extend_from_slice(&value.to_be_bytes());
+}
+
+fn append_png_chunk(output: &mut Vec<u8>, kind: &[u8; 4], data: &[u8]) {
+    append_u32_be(output, data.len() as u32);
+    output.extend_from_slice(kind);
+    output.extend_from_slice(data);
+
+    let mut crc = 0xFFFF_FFFF;
+    crc = crc32_update(crc, kind);
+    crc = crc32_update(crc, data);
+    append_u32_be(output, !crc);
+}
+
+fn png_from_idat(size: u32, bit_depth: u8, color_type: u8, compressed: &[u8]) -> Vec<u8> {
+    let mut ihdr = [0u8; 13];
+    ihdr[..4].copy_from_slice(&size.to_be_bytes());
+    ihdr[4..8].copy_from_slice(&size.to_be_bytes());
+    ihdr[8] = bit_depth;
+    ihdr[9] = color_type;
+
+    let mut png = Vec::with_capacity(PNG_SIGNATURE.len() + 25 + compressed.len() + 12);
+    png.extend_from_slice(&PNG_SIGNATURE);
+    append_png_chunk(&mut png, b"IHDR", &ihdr);
+    append_png_chunk(&mut png, b"IDAT", compressed);
+    append_png_chunk(&mut png, b"IEND", &[]);
+    png
+}
+
+fn zlib_stored_blocks(data: &[u8]) -> Vec<u8> {
+    let mut output = Vec::with_capacity(data.len() + (data.len() / 65_535 + 1) * 5 + 6);
+    output.extend_from_slice(&[0x78, 0x01]);
+
+    let chunks = data.len().div_ceil(65_535);
+    for (index, chunk) in data.chunks(65_535).enumerate() {
+        let is_final = index + 1 == chunks;
+        output.push(u8::from(is_final));
+
+        let len = chunk.len() as u16;
+        let nlen = !len;
+        output.extend_from_slice(&len.to_le_bytes());
+        output.extend_from_slice(&nlen.to_le_bytes());
+        output.extend_from_slice(chunk);
+    }
+
+    append_u32_be(&mut output, adler32(data));
+    output
+}
+
+fn blit_packed_bits(dst: &mut [u8], bit_offset: usize, src: &[u8], bit_len: usize) {
+    if bit_len == 0 {
+        return;
+    }
+
+    let byte_offset = bit_offset / 8;
+    let shift = bit_offset % 8;
+    let full_bytes = bit_len / 8;
+    let tail_bits = bit_len % 8;
+
+    if shift == 0 {
+        if full_bytes != 0 {
+            dst[byte_offset..byte_offset + full_bytes].copy_from_slice(&src[..full_bytes]);
+        }
+
+        if tail_bits != 0 {
+            let mask = 0xFF << (8 - tail_bits);
+            let idx = byte_offset + full_bytes;
+            dst[idx] &= !mask;
+            dst[idx] |= src[full_bytes] & mask;
+        }
+
+        return;
+    }
+
+    let mut out = byte_offset;
+
+    for &byte in &src[..full_bytes] {
+        dst[out] &= byte >> shift;
+        if out + 1 < dst.len() {
+            dst[out + 1] &= byte << (8 - shift);
+        }
+        out += 1;
+    }
+
+    if tail_bits != 0 {
+        let byte = src[full_bytes];
+        let mask = 0xFF << (8 - tail_bits);
+
+        dst[out] &= (byte & mask) >> shift;
+
+        let used_in_next = tail_bits.saturating_sub(8 - shift);
+        if used_in_next != 0 && out + 1 < dst.len() {
+            let next_mask = 0xFF << (8 - used_in_next);
+            dst[out + 1] &= (byte << (8 - shift)) | !next_mask;
+        }
+    }
+}
+
+fn pack_qr_row_scalar<M>(qr_row: &[M], out: &mut [u8], value: impl Fn(&M) -> bool) {
+    let mut x = 0usize;
+    let mut i = 0usize;
+
+    while x + 8 <= qr_row.len() {
+        let mut byte = 0xFFu8;
+
+        if value(&qr_row[x]) {
+            byte &= !(1 << 7);
+        }
+        if value(&qr_row[x + 1]) {
+            byte &= !(1 << 6);
+        }
+        if value(&qr_row[x + 2]) {
+            byte &= !(1 << 5);
+        }
+        if value(&qr_row[x + 3]) {
+            byte &= !(1 << 4);
+        }
+        if value(&qr_row[x + 4]) {
+            byte &= !(1 << 3);
+        }
+        if value(&qr_row[x + 5]) {
+            byte &= !(1 << 2);
+        }
+        if value(&qr_row[x + 6]) {
+            byte &= !(1 << 1);
+        }
+        if value(&qr_row[x + 7]) {
+            byte &= !(1 << 0);
+        }
+
+        out[i] = byte;
+        x += 8;
+        i += 1;
+    }
+
+    if x < qr_row.len() {
+        let mut byte = 0xFFu8;
+
+        for (bit, module) in qr_row[x..].iter().enumerate() {
+            if value(module) {
+                byte &= !(1 << (7 - bit));
+            }
+        }
+
+        out[i] = byte;
+    }
+}
+
+fn encode_qr_to_smol_png_1bit(qr: &QRCode, quiet_zone: u32) -> Vec<u8> {
+    let module_count = qr.size as usize;
+    let quiet = quiet_zone as usize;
+    let size = module_count + quiet * 2;
+    let packed_row_len = size.div_ceil(8);
+    let row_len = 1 + packed_row_len;
+
+    let mut raw = vec![0xFFu8; row_len * size];
+    for y in 0..size {
+        raw[y * row_len] = 0;
+    }
+
+    let qr_packed_len = module_count.div_ceil(8);
+    let mut packed_row = vec![0xFFu8; qr_packed_len];
+
+    for my in 0..module_count {
+        packed_row.fill(0xFF);
+
+        let qr_row = &qr.data[my * module_count..(my + 1) * module_count];
+        pack_qr_row_scalar(qr_row, &mut packed_row, |m| m.value());
+
+        let out_row = (my + quiet) * row_len;
+        let dst = &mut raw[out_row + 1..out_row + row_len];
+        if quiet % 8 == 0 {
+            let byte_offset = quiet / 8;
+            dst[byte_offset..byte_offset + qr_packed_len].copy_from_slice(&packed_row);
+        } else {
+            blit_packed_bits(dst, quiet, &packed_row, module_count);
+        }
+    }
+
+    let compressed = zlib_stored_blocks(&raw);
+    png_from_idat(size as u32, 1, 0, &compressed)
+}
+
+pub fn encode(qr: &QRCode, scale: u32, quiet_zone: u32) -> Vec<u8> {
+    if scale == 0 {
+        return Vec::new();
+    }
+
+    if scale == 1 {
+        return encode_qr_to_smol_png_1bit(qr, quiet_zone);
+    }
+
+    let module_count = qr.size as u32;
+    let image_module_count = module_count + quiet_zone * 2;
+    let size = image_module_count * scale;
+    let row_length = 1 + size as usize;
+    let mut raw = vec![0u8; row_length * size as usize];
+
+    for y in 0..size as usize {
+        let row_offset = y * row_length;
+        let module_y = y as u32 / scale;
+
+        for x in 0..size as usize {
+            let module_x = x as u32 / scale;
+            let in_bounds = module_x >= quiet_zone
+                && module_x < quiet_zone + module_count
+                && module_y >= quiet_zone
+                && module_y < quiet_zone + module_count;
+
+            let is_dark = in_bounds
+                && qr.data
+                    [((module_y - quiet_zone) * module_count + (module_x - quiet_zone)) as usize]
+                    .value();
+
+            raw[row_offset + 1 + x] = if is_dark { 0 } else { 255 };
+        }
+    }
+
+    let compressed = zlib_stored_blocks(&raw);
+    png_from_idat(size, 8, 0, &compressed)
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,15 @@
 use crate::QRCode;
+#[cfg(feature = "image")]
+use crate::convert::image::ImageBuilder;
+use crate::smol_png;
+#[cfg(any(feature = "svg", feature = "wasm-bindgen"))]
+use crate::{ECL, Version};
 #[cfg(feature = "svg")]
-use crate::{convert, Version, ECL};
+use crate::convert;
+#[cfg(any(feature = "svg", feature = "image"))]
+use crate::convert::Builder;
+#[cfg(feature = "wasm-bindgen")]
+use js_sys::Reflect;
 #[cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::prelude::*;
 
@@ -18,6 +27,110 @@ fn bool_to_u8(qr: QRCode) -> Vec<u8> {
 pub fn qr(content: &str) -> Vec<u8> {
     let qrcode = QRCode::new(content.as_bytes(), None, None, None, None);
     qrcode.map(bool_to_u8).unwrap_or(Vec::new())
+}
+
+#[derive(Debug, Clone)]
+struct SmolImageOptions {
+    scale: u32,
+    quiet_zone: u32,
+    ecl: Option<ECL>,
+    version: Option<Version>,
+}
+
+impl SmolImageOptions {
+    fn new() -> Self {
+        Self {
+            scale: 1,
+            quiet_zone: 4,
+            ecl: None,
+            version: None,
+        }
+    }
+}
+
+#[cfg(feature = "wasm-bindgen")]
+fn get_js_value(object: &JsValue, key: &str) -> Option<JsValue> {
+    Reflect::get(object, &JsValue::from_str(key))
+        .ok()
+        .filter(|value| !value.is_undefined() && !value.is_null())
+}
+
+#[cfg(feature = "wasm-bindgen")]
+fn parse_smol_image_options(options: &JsValue) -> SmolImageOptions {
+    let mut parsed = SmolImageOptions::new();
+
+    if let Some(scale) = get_js_value(options, "scale").and_then(|value| value.as_f64()) {
+        if scale.is_finite() && scale >= 0.0 {
+            parsed.scale = scale as u32;
+        }
+    }
+
+    let quiet_zone = get_js_value(options, "quietZone")
+        .or_else(|| get_js_value(options, "quiet_zone"))
+        .and_then(|value| value.as_f64());
+    if let Some(quiet_zone) = quiet_zone {
+        if quiet_zone.is_finite() && quiet_zone >= 0.0 {
+            parsed.quiet_zone = quiet_zone as u32;
+        }
+    }
+
+    if let Some(ecl) = get_js_value(options, "ecl").and_then(|value| value.as_f64()) {
+        parsed.ecl = match ecl as u32 {
+            0 => Some(ECL::L),
+            1 => Some(ECL::M),
+            2 => Some(ECL::Q),
+            3 => Some(ECL::H),
+            _ => None,
+        };
+    }
+
+    if let Some(version) = get_js_value(options, "version").and_then(|value| value.as_f64()) {
+        parsed.version = match version as usize {
+            0 => Some(Version::V01),
+            1 => Some(Version::V02),
+            2 => Some(Version::V03),
+            3 => Some(Version::V04),
+            4 => Some(Version::V05),
+            5 => Some(Version::V06),
+            6 => Some(Version::V07),
+            7 => Some(Version::V08),
+            8 => Some(Version::V09),
+            9 => Some(Version::V10),
+            10 => Some(Version::V11),
+            11 => Some(Version::V12),
+            12 => Some(Version::V13),
+            13 => Some(Version::V14),
+            14 => Some(Version::V15),
+            15 => Some(Version::V16),
+            16 => Some(Version::V17),
+            17 => Some(Version::V18),
+            18 => Some(Version::V19),
+            19 => Some(Version::V20),
+            20 => Some(Version::V21),
+            21 => Some(Version::V22),
+            22 => Some(Version::V23),
+            23 => Some(Version::V24),
+            24 => Some(Version::V25),
+            25 => Some(Version::V26),
+            26 => Some(Version::V27),
+            27 => Some(Version::V28),
+            28 => Some(Version::V29),
+            29 => Some(Version::V30),
+            30 => Some(Version::V31),
+            31 => Some(Version::V32),
+            32 => Some(Version::V33),
+            33 => Some(Version::V34),
+            34 => Some(Version::V35),
+            35 => Some(Version::V36),
+            36 => Some(Version::V37),
+            37 => Some(Version::V38),
+            38 => Some(Version::V39),
+            39 => Some(Version::V40),
+            _ => None,
+        };
+    }
+
+    parsed
 }
 
 /// Configuration for the SVG output.
@@ -201,7 +314,6 @@ impl SvgOptions {
 #[cfg(feature = "svg")]
 pub fn qr_svg(content: &str, options: SvgOptions) -> String {
     use crate::convert::svg::SvgBuilder;
-    use crate::convert::Builder;
     let qrcode = QRCode::new(content.as_bytes(), options.ecl, options.version, None, None);
 
     let mut builder = SvgBuilder::default();
@@ -233,4 +345,51 @@ pub fn qr_svg(content: &str, options: SvgOptions) -> String {
     qrcode
         .map(|qrcode| builder.to_str(&qrcode))
         .unwrap_or(String::new())
+}
+
+/// Generate a PNG QR code from a string.
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
+#[cfg(feature = "image")]
+pub fn qr_image(content: &str, options: SvgOptions) -> Vec<u8> {
+    let qrcode = QRCode::new(content.as_bytes(), options.ecl, options.version, None, None);
+
+    let mut builder = ImageBuilder::default();
+    builder.shape(options.shape);
+    builder.margin(options.margin);
+    builder.background_color(options.background_color);
+    builder.module_color(options.module_color);
+    if !options.image.is_empty() {
+        builder.image(options.image);
+    }
+
+    builder.image_background_color(options.image_background_color);
+    builder.image_background_shape(options.image_background_shape);
+
+    if let Some(image_size) = options.image_size {
+        builder.image_size(image_size);
+    }
+
+    if let Some(image_gap) = options.image_gap {
+        builder.image_gap(image_gap);
+    }
+
+    if options.image_position.len() == 2 {
+        let x = options.image_position[0];
+        let y = options.image_position[1];
+        builder.image_position(x, y);
+    }
+
+    match qrcode {
+        Ok(qrcode) => builder.to_bytes(&qrcode).unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Generate a tiny grayscale PNG QR code from a string.
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
+pub fn qr_smol_image(content: &str, options: JsValue) -> Vec<u8> {
+    let options = parse_smol_image_options(&options);
+    QRCode::new(content.as_bytes(), options.ecl, options.version, None, None)
+        .map(|qrcode| smol_png::encode(&qrcode, options.scale, options.quiet_zone))
+        .unwrap_or_default()
 }


### PR DESCRIPTION
I got a bit confused when installing the fast_qr package from NPM, it seemed like it would have a image method because the rust version did. Looking at the issues I understand the tradeoff why its not included in the wasm build. I'm suggesting adding some lightweight PNG encoder to produce tiny PNGs. Since the images are really simple if you don't allow any styling options and only focus on a functioning qrcode the code required for such an encoder is small. 

Adds a lightweight PNG encoder for QR codes that produces tiny grayscale PNGs without the overhead of the full image/resvg stack.

- Adds src/smol_png.rs with 1-bit PNG encoding optimized for QR codes
- Adds qr_smol_image() function for WASM target
- Updates README with documentation and bundle size comparison
- Adds js-sys dependency for option parsing in WASM


From my benchmarking on my Macbook M1 I can generate pngs using qr_smol_image in around 100us in wasm, faster than it currently generates a SVG.
qr_smol_image       avg   98.39 us  total 196.773 ms  10.16 k ops/s
