### PR TITLE
perf(svg): optimize SVG generation with direct buffer writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ include = ["src", "Cargo.toml", "./README.md", "./LICENSE", "benches"]
 rust-version = "1.59"
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/benches/qr.rs
+++ b/benches/qr.rs
@@ -3,7 +3,91 @@ use std::time::Duration;
 use criterion::*;
 use std::hint::black_box;
 
-use fast_qr::QRBuilder;
+use fast_qr::convert::svg::SvgBuilder;
+use fast_qr::convert::{Builder, Shape};
+use fast_qr::{QRBuilder, Version, ECL};
+
+fn bench_fastqr_svg(c: &mut Criterion) {
+    let qrcode = QRBuilder::new("https://example.com/").build().unwrap();
+
+    let mut group = c.benchmark_group("svg");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(200);
+
+    group.bench_function("to_str", |b| {
+        b.iter(|| {
+            let svg = SvgBuilder::default().shape(Shape::Square).to_str(&qrcode);
+            black_box(svg);
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_svg_shapes(c: &mut Criterion) {
+    let qrcode = QRBuilder::new("https://example.com/").build().unwrap();
+
+    let mut group = c.benchmark_group("svg_shapes");
+    group.measurement_time(Duration::from_secs(5));
+    group.sample_size(100);
+
+    for shape in &[
+        Shape::Square,
+        Shape::Circle,
+        Shape::RoundedSquare,
+        Shape::Vertical,
+        Shape::Horizontal,
+        Shape::Diamond,
+    ] {
+        let shape_name: &str = (*shape).into();
+        group.bench_function(shape_name, |b| {
+            b.iter(|| {
+                let svg = SvgBuilder::default().shape(*shape).to_str(&qrcode);
+                black_box(svg);
+            })
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_svg_versions(c: &mut Criterion) {
+    for (version, name) in &[
+        (Version::V03, "V03"),
+        (Version::V10, "V10"),
+        (Version::V20, "V20"),
+        (Version::V30, "V30"),
+        (Version::V40, "V40"),
+    ] {
+        let qrcode = QRBuilder::new("https://example.com/")
+            .ecl(ECL::H)
+            .version(*version)
+            .build()
+            .unwrap();
+
+        let mut group = c.benchmark_group(format!("svg_versions/{}", name));
+        group.measurement_time(Duration::from_secs(5));
+        group.sample_size(100);
+
+        group.bench_function("square", |b| {
+            b.iter(|| {
+                let svg = SvgBuilder::default().shape(Shape::Square).to_str(&qrcode);
+                black_box(svg);
+            })
+        });
+
+        group.bench_function("rounded_square", |b| {
+            b.iter(|| {
+                let svg = SvgBuilder::default()
+                    .shape(Shape::RoundedSquare)
+                    .to_str(&qrcode);
+                black_box(svg);
+            })
+        });
+
+        group.finish();
+    }
+}
 
 fn bench_fastqr_qrcode(c: &mut Criterion) {
     let bytes: &[u8] = b"https://example.com/";
@@ -61,5 +145,11 @@ fn bench_fastqr_qrcode(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_fastqr_qrcode);
+criterion_group!(
+    benches,
+    bench_fastqr_qrcode,
+    bench_fastqr_svg,
+    bench_svg_shapes,
+    bench_svg_versions
+);
 criterion_main!(benches);

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -29,6 +29,20 @@ use crate::Module;
 /// ```
 pub type ModuleFunction = fn(usize, usize, Module) -> String;
 
+/// Writer function type for SVG generation
+/// # Example
+///
+/// For the square shape, the svg is `M{x},{y}h1v1h-1`
+///
+/// ```rust
+/// # use fast_qr::Module;
+/// use core::fmt::Write;
+/// fn write_square(out: &mut String, y: usize, x: usize, _module: Module) {
+///     let _ = write!(out, "M{x},{y}h1v1h-1");
+/// }
+/// ```
+pub type ModuleWriter = fn(&mut String, usize, usize, Module);
+
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 use wasm_bindgen::prelude::*;
 
@@ -185,6 +199,200 @@ impl Deref for Shape {
             _ => &Self::FUNCTIONS[index],
         }
     }
+}
+
+/// SVG module writer functions that use direct string operations
+pub mod writers {
+    use crate::Module;
+
+    const COORD_CACHE_SIZE: usize = 200;
+    const SIMPLE_COORD_WIDTH: usize = 3; // "199"
+    const DECIMAL_COORD_WIDTH: usize = 5; // "199.8"
+
+    const fn digit_count(n: usize) -> u8 {
+        if n >= 100 {
+            3
+        } else if n >= 10 {
+            2
+        } else {
+            1
+        }
+    }
+
+    const fn build_coord_cache() -> ([[u8; SIMPLE_COORD_WIDTH]; COORD_CACHE_SIZE], [u8; COORD_CACHE_SIZE]) {
+        let mut values = [[0; SIMPLE_COORD_WIDTH]; COORD_CACHE_SIZE];
+        let mut lens = [0; COORD_CACHE_SIZE];
+        let mut i = 0;
+
+        while i < COORD_CACHE_SIZE {
+            let len = digit_count(i);
+            lens[i] = len;
+
+            if i >= 100 {
+                values[i][0] = b'0' + (i / 100) as u8;
+                values[i][1] = b'0' + ((i / 10) % 10) as u8;
+                values[i][2] = b'0' + (i % 10) as u8;
+            } else if i >= 10 {
+                values[i][0] = b'0' + (i / 10) as u8;
+                values[i][1] = b'0' + (i % 10) as u8;
+            } else {
+                values[i][0] = b'0' + i as u8;
+            }
+
+            i += 1;
+        }
+
+        (values, lens)
+    }
+
+    const fn build_decimal_coord_cache<const SUFFIX: u8>(
+    ) -> ([[u8; DECIMAL_COORD_WIDTH]; COORD_CACHE_SIZE], [u8; COORD_CACHE_SIZE]) {
+        let mut values = [[0; DECIMAL_COORD_WIDTH]; COORD_CACHE_SIZE];
+        let mut lens = [0; COORD_CACHE_SIZE];
+        let mut i = 0;
+
+        while i < COORD_CACHE_SIZE {
+            let len = digit_count(i);
+            lens[i] = len + 2;
+
+            if i >= 100 {
+                values[i][0] = b'0' + (i / 100) as u8;
+                values[i][1] = b'0' + ((i / 10) % 10) as u8;
+                values[i][2] = b'0' + (i % 10) as u8;
+                values[i][3] = b'.';
+                values[i][4] = b'0' + SUFFIX;
+            } else if i >= 10 {
+                values[i][0] = b'0' + (i / 10) as u8;
+                values[i][1] = b'0' + (i % 10) as u8;
+                values[i][2] = b'.';
+                values[i][3] = b'0' + SUFFIX;
+            } else {
+                values[i][0] = b'0' + i as u8;
+                values[i][1] = b'.';
+                values[i][2] = b'0' + SUFFIX;
+            }
+
+            i += 1;
+        }
+
+        (values, lens)
+    }
+
+    const COORD_CACHE: ([[u8; SIMPLE_COORD_WIDTH]; COORD_CACHE_SIZE], [u8; COORD_CACHE_SIZE]) =
+        build_coord_cache();
+    const COORD_CACHE_2: ([[u8; DECIMAL_COORD_WIDTH]; COORD_CACHE_SIZE], [u8; COORD_CACHE_SIZE]) =
+        build_decimal_coord_cache::<2>();
+    const COORD_CACHE_8: ([[u8; DECIMAL_COORD_WIDTH]; COORD_CACHE_SIZE], [u8; COORD_CACHE_SIZE]) =
+        build_decimal_coord_cache::<8>();
+
+    #[inline]
+    fn push_cached<const WIDTH: usize>(
+        out: &mut String,
+        cache: &([[u8; WIDTH]; COORD_CACHE_SIZE], [u8; COORD_CACHE_SIZE]),
+        n: usize,
+    ) -> bool {
+        if n >= COORD_CACHE_SIZE {
+            return false;
+        }
+
+        let len = cache.1[n] as usize;
+        let bytes = &cache.0[n][..len];
+
+        // SAFETY: The cache is built entirely from ASCII digits and '.'.
+        out.push_str(unsafe { core::str::from_utf8_unchecked(bytes) });
+        true
+    }
+
+    /// Helper to push a usize to string using cache when possible
+    #[inline]
+    fn push_usize(out: &mut String, n: usize) {
+        if !push_cached(out, &COORD_CACHE, n) {
+            out.push_str(&n.to_string());
+        }
+    }
+
+    /// Writer function for square shape
+    pub fn write_square(out: &mut String, y: usize, x: usize, _: Module) {
+        out.push('M');
+        push_usize(out, x);
+        out.push(',');
+        push_usize(out, y);
+        out.push_str("h1v1h-1");
+    }
+
+    /// Writer function for circle shape
+    pub fn write_circle(out: &mut String, y: usize, x: usize, _: Module) {
+        out.push('M');
+        push_usize(out, x + 1);
+        out.push(',');
+        push_usize(out, y);
+        out.push_str(".5a.5,.5 0 1,1 0,-.1");
+    }
+
+    /// Writer function for rounded square shape with decimal-prefixed coordinate caching
+    pub fn write_rounded_square(out: &mut String, y: usize, x: usize, _: Module) {
+        if x < 200 && y < 200 {
+            // Fast path: use cached strings with decimals
+            out.push('M');
+            let _ = push_cached(out, &COORD_CACHE_2, x);
+            out.push(',');
+            let _ = push_cached(out, &COORD_CACHE_2, y);
+            out.push(' ');
+            let _ = push_cached(out, &COORD_CACHE_8, x);
+            out.push(',');
+            let _ = push_cached(out, &COORD_CACHE_2, y);
+            out.push(' ');
+            let _ = push_cached(out, &COORD_CACHE_8, x);
+            out.push(',');
+            let _ = push_cached(out, &COORD_CACHE_8, y);
+            out.push(' ');
+            let _ = push_cached(out, &COORD_CACHE_2, x);
+            out.push(',');
+            let _ = push_cached(out, &COORD_CACHE_8, y);
+            out.push('z');
+        } else {
+            // Fallback for coordinates > 199 (very rare, only V40+ with high margin)
+            use core::fmt::Write;
+            let _ = write!(out, "M{x}.2,{y}.2 {x}.8,{y}.2 {x}.8,{y}.8 {x}.2,{y}.8z");
+        }
+    }
+
+    /// Writer function for horizontal shape
+    pub fn write_horizontal(out: &mut String, y: usize, x: usize, _: Module) {
+        out.push('M');
+        push_usize(out, x);
+        out.push(',');
+        push_usize(out, y);
+        out.push_str(".1h1v.8h-1");
+    }
+
+    /// Writer function for vertical shape
+    pub fn write_vertical(out: &mut String, y: usize, x: usize, _: Module) {
+        out.push('M');
+        push_usize(out, x);
+        out.push_str(".1,");
+        push_usize(out, y);
+        out.push_str("h.8v1h-.8");
+    }
+
+    /// Writer function for diamond shape
+    pub fn write_diamond(out: &mut String, y: usize, x: usize, _: Module) {
+        out.push('M');
+        push_usize(out, x);
+        out.push_str(".5,");
+        push_usize(out, y);
+        out.push_str("l.5,.5l-.5,.5l-.5,-.5z");
+    }
+
+    /// Array of all writer functions
+    pub const WRITERS: [super::ModuleWriter; 6] = [
+        write_square,
+        write_circle,
+        write_rounded_square,
+        write_vertical,
+        write_horizontal,
+        write_diamond,
+    ];
 }
 
 /// Different possible image background shapes

--- a/src/convert/svg.rs
+++ b/src/convert/svg.rs
@@ -21,19 +21,25 @@
 //! # }
 //! ```
 
+use core::fmt::Write;
+
 use crate::{QRCode, Version};
 
-use super::{Builder, Color, ImageBackgroundShape, ModuleFunction, Shape};
+use super::{Builder, Color, ImageBackgroundShape, ModuleWriter, Shape};
 
 /// Builder for svg, can set shape, margin, background_color, dot_color
 pub struct SvgBuilder {
     /// Command vector allows predefined or custom shapes
     /// The default is square, commands can be added using `.shape()`
-    commands: Vec<ModuleFunction>,
+    commands: Vec<ModuleWriter>,
     /// Commands can also have a custom color
     /// The default is `dot_color`, commands with specific colors can be
     /// added using `.shape_color()`
     command_colors: Vec<Option<Color>>,
+    /// Whether each command needs stroke attribute (pre-computed to avoid runtime comparison)
+    commands_needs_stroke: Vec<bool>,
+    /// Average bytes per module for each command (for capacity pre-allocation)
+    commands_bytes_per_module: Vec<usize>,
     /// The margin for the svg, default is 4
     margin: usize,
     /// The background color for the svg, default is #FFFFFF
@@ -75,6 +81,8 @@ impl Default for SvgBuilder {
             margin: 4,
             commands: Vec::new(),
             command_colors: Vec::new(),
+            commands_needs_stroke: Vec::new(),
+            commands_bytes_per_module: Vec::new(),
 
             // Image Embedding
             image: None,
@@ -104,14 +112,48 @@ impl Builder for SvgBuilder {
     }
 
     fn shape(&mut self, shape: Shape) -> &mut Self {
-        self.commands.push(*shape);
+        use super::writers::WRITERS;
+        /// Estimate bytes needed per QR module for a given SVG path pattern.
+        /// Pattern length + 4 for coordinate digits (e.g., "12,34") + small overhead
+        const fn estimated_bytes(pattern: &'static str) -> usize {
+            pattern.len() + 6 // +6 accounts for coordinates and safety margin
+        }
+        const BYTES_PER_MODULE: [usize; 6] = [
+            estimated_bytes("M{x},{y}h1v1h-1"),              // Square
+            estimated_bytes("M{x},{y}.5a.5,.5 0 1,1 0,-.1"), // Circle
+            estimated_bytes("M{x}.2,{y}.2 {x}.8,{y}.2 {x}.8,{y}.8 {x}.2,{y}.8z"), // RoundedSquare
+            estimated_bytes("M{x}.1,{y}h.8v1h-.8"),          // Vertical
+            estimated_bytes("M{x},{y}.1h1v.8h-1"),           // Horizontal
+            estimated_bytes("M{x}.5,{y}l.5,.5l-.5,.5l-.5,-.5z"), // Diamond
+        ];
+        let index: usize = shape.into();
+        self.commands.push(WRITERS[index]);
         self.command_colors.push(None);
+        self.commands_needs_stroke.push(index == 2); // RoundedSquare is index 2
+        self.commands_bytes_per_module.push(BYTES_PER_MODULE[index]);
         self
     }
 
     fn shape_color<C: Into<Color>>(&mut self, shape: Shape, color: C) -> &mut Self {
-        self.commands.push(*shape);
+        use super::writers::WRITERS;
+        /// Estimate bytes needed per QR module for a given SVG path pattern.
+        /// Pattern length + 4 for coordinate digits (e.g., "12,34") + small overhead
+        const fn estimated_bytes(pattern: &'static str) -> usize {
+            pattern.len() + 6 // +6 accounts for coordinates and safety margin
+        }
+        const BYTES_PER_MODULE: [usize; 6] = [
+            estimated_bytes("M{x},{y}h1v1h-1"),              // Square
+            estimated_bytes("M{x},{y}.5a.5,.5 0 1,1 0,-.1"), // Circle
+            estimated_bytes("M{x}.2,{y}.2 {x}.8,{y}.2 {x}.8,{y}.8 {x}.2,{y}.8z"), // RoundedSquare
+            estimated_bytes("M{x}.1,{y}h.8v1h-.8"),          // Vertical
+            estimated_bytes("M{x},{y}.1h1v.8h-1"),           // Horizontal
+            estimated_bytes("M{x}.5,{y}l.5,.5l-.5,.5l-.5,-.5z"), // Diamond
+        ];
+        let index: usize = shape.into();
+        self.commands.push(WRITERS[index]);
         self.command_colors.push(Some(color.into()));
+        self.commands_needs_stroke.push(index == 2); // RoundedSquare is index 2
+        self.commands_bytes_per_module.push(BYTES_PER_MODULE[index]);
         self
     }
 
@@ -191,7 +233,7 @@ impl SvgBuilder {
         }
 
         let image = self.image.as_ref().unwrap();
-        let mut out = String::with_capacity(image.len() + 100);
+        let mut out = String::with_capacity(image.len() + 200);
 
         let (mut border_size, mut image_size) =
             Self::image_placement(self.image_background_shape, n);
@@ -222,40 +264,61 @@ impl SvgBuilder {
             placed_coord = (x - border_size / 2f64, y - border_size / 2f64);
         }
 
-        let format = match self.image_background_shape {
+        match self.image_background_shape {
             ImageBackgroundShape::Square => {
-                r#"<rect x="{0}" y="{1}" width="{2}" height="{2}" fill="{3}"/>"#
+                let _ = write!(
+                    out,
+                    r#"<rect x="{}" y="{}" width="{}" height="{}" fill="{}"/>"#,
+                    placed_coord.0,
+                    placed_coord.1,
+                    border_size,
+                    border_size,
+                    self.image_background_color.to_str()
+                );
             }
             ImageBackgroundShape::Circle => {
-                r#"<rect x="{0}" y="{1}" width="{2}" height="{2}" fill="{3}" rx="1000px"/>"#
+                let _ = write!(
+                    out,
+                    r#"<rect x="{}" y="{}" width="{}" height="{}" fill="{}" rx="1000px"/>"#,
+                    placed_coord.0,
+                    placed_coord.1,
+                    border_size,
+                    border_size,
+                    self.image_background_color.to_str()
+                );
             }
             ImageBackgroundShape::RoundedSquare => {
-                r#"<rect x="{0}" y="{1}" width="{2}" height="{2}" fill="{3}" rx="1px"/>"#
+                let _ = write!(
+                    out,
+                    r#"<rect x="{}" y="{}" width="{}" height="{}" fill="{}" rx="1px"/>"#,
+                    placed_coord.0,
+                    placed_coord.1,
+                    border_size,
+                    border_size,
+                    self.image_background_color.to_str()
+                );
             }
         };
 
-        let format = format
-            .replace("{0}", &placed_coord.0.to_string())
-            .replace("{1}", &placed_coord.1.to_string())
-            .replace("{2}", &border_size.to_string())
-            .replace("{3}", self.image_background_color.to_str());
-
-        out.push_str(&format);
-
-        out.push_str(&format!(
-            r#"<image x="{0:.2}" y="{1:.2}" width="{2:.2}" height="{2:.2}" href="{3}" />"#,
+        let _ = write!(
+            out,
+            r#"<image x="{:.2}" y="{:.2}" width="{:.2}" height="{:.2}" href="{}" />"#,
             placed_coord.0 + (border_size - image_size) / 2f64,
             placed_coord.1 + (border_size - image_size) / 2f64,
             image_size,
+            image_size,
             image
-        ));
+        );
 
         out
     }
 
     fn path(&self, qr: &QRCode) -> String {
-        const DEFAULT_COMMAND: [ModuleFunction; 1] = [Shape::square];
+        use super::writers::WRITERS;
+        const DEFAULT_COMMAND: [ModuleWriter; 1] = [WRITERS[0]];
         const DEFAULT_COMMAND_COLOR: [Option<Color>; 1] = [None];
+        const DEFAULT_NEEDS_STROKE: [bool; 1] = [false];
+        const DEFAULT_BYTES_PER_MODULE: [usize; 1] = [16]; // Square
 
         // TODO: cleanup this basic logic
         let command_colors: &[Option<Color>] = if !self.commands.is_empty() {
@@ -263,15 +326,59 @@ impl SvgBuilder {
         } else {
             &DEFAULT_COMMAND_COLOR
         };
-        let commands: &[ModuleFunction] = if !self.commands.is_empty() {
+        let commands: &[ModuleWriter] = if !self.commands.is_empty() {
             &self.commands
         } else {
             &DEFAULT_COMMAND
         };
+        let needs_stroke: &[bool] = if !self.commands.is_empty() {
+            &self.commands_needs_stroke
+        } else {
+            &DEFAULT_NEEDS_STROKE
+        };
+        let bytes_per_module: &[usize] = if !self.commands.is_empty() {
+            &self.commands_bytes_per_module
+        } else {
+            &DEFAULT_BYTES_PER_MODULE
+        };
 
-        let mut paths = vec![String::with_capacity(10 * qr.size * qr.size); commands.len()];
+        // Fast path: single command (most common case) - build directly without Vec
+        if commands.len() == 1 {
+            let module_count = qr.size * qr.size / 2;
+            let mut out = String::with_capacity(9 + bytes_per_module[0] * module_count + 50);
+            let _ = write!(out, r#"<path d=""#);
+
+            for y in 0..qr.size {
+                let line = &qr[y];
+                for (x, &cell) in line.iter().enumerate() {
+                    if cell.value() {
+                        commands[0](&mut out, y + self.margin, x + self.margin, cell);
+                    }
+                }
+            }
+
+            let command_color = command_colors[0].as_ref().unwrap_or(&self.dot_color);
+            if needs_stroke[0] {
+                let _ = write!(
+                    out,
+                    r##"" stroke-width=".3" stroke-linejoin="round" stroke="{}"##,
+                    command_color.to_str()
+                );
+            }
+            let _ = write!(out, r#"" fill="{}"/>"#, command_color.to_str());
+
+            return out;
+        }
+
+        // Multi-command path: use Vec for multiple shapes
+        let module_count = qr.size * qr.size / 2;
+        let mut paths: Vec<String> = commands
+            .iter()
+            .enumerate()
+            .map(|(i, _)| String::with_capacity(9 + bytes_per_module[i] * module_count + 50))
+            .collect();
         for path in paths.iter_mut() {
-            path.push_str(r#"<path d=""#);
+            let _ = write!(path, r#"<path d=""#);
         }
 
         for y in 0..qr.size {
@@ -282,23 +389,21 @@ impl SvgBuilder {
                 }
 
                 for (i, command) in commands.iter().enumerate() {
-                    paths[i].push_str(&command(y + self.margin, x + self.margin, cell));
+                    command(&mut paths[i], y + self.margin, x + self.margin, cell);
                 }
             }
         }
 
-        for (i, &command) in commands.iter().enumerate() {
+        for (i, _) in commands.iter().enumerate() {
             let command_color = command_colors[i].as_ref().unwrap_or(&self.dot_color);
-            // Allows to compare if two function pointers are the same
-            // This works because there is no notion of Generics for `rounded_square`
-            if command as usize == Shape::rounded_square as usize {
-                paths[i].push_str(&format!(
+            if needs_stroke[i] {
+                let _ = write!(
+                    paths[i],
                     r##"" stroke-width=".3" stroke-linejoin="round" stroke="{}"##,
                     command_color.to_str()
-                ));
+                );
             }
-
-            paths[i].push_str(&format!(r#"" fill="{}"/>"#, command_color.to_str()));
+            let _ = write!(paths[i], r#"" fill="{}"/>"#, command_color.to_str());
         }
 
         paths.join("")
@@ -308,17 +413,34 @@ impl SvgBuilder {
     pub fn to_str(&self, qr: &QRCode) -> String {
         let n = qr.size;
 
-        let mut out = String::with_capacity(11 * n * n / 2);
-        out.push_str(&format!(
+        // Calculate better capacity based on shapes used
+        // Base: svg tag (~60) + rect tag (~60) + image (~200) + closing tag (~10)
+        // Path data: depends on shape and module count (~50% fill rate)
+        let module_count = n * n / 2;
+        let path_capacity: usize = if !self.commands.is_empty() {
+            self.commands_bytes_per_module
+                .iter()
+                .map(|&b| 60 + b * module_count)
+                .sum()
+        } else {
+            60 + 16 * module_count // Default square
+        };
+        let capacity = 130 + path_capacity;
+
+        let mut out = String::with_capacity(capacity);
+        let _ = write!(
+            out,
             r#"<svg viewBox="0 0 {0} {0}" xmlns="http://www.w3.org/2000/svg">"#,
             self.margin * 2 + n
-        ));
+        );
 
-        out.push_str(&format!(
-            r#"<rect width="{0}px" height="{0}px" fill="{1}"/>"#,
+        let _ = write!(
+            out,
+            r#"<rect width="{}px" height="{}px" fill="{}"/>"#,
+            self.margin * 2 + n,
             self.margin * 2 + n,
             self.background_color.to_str()
-        ));
+        );
 
         out.push_str(&self.path(qr));
         out.push_str(&self.image(n));


### PR DESCRIPTION
Replace per-module String allocation with direct buffer writing:

- Add ModuleWriter type that writes to &mut String instead of returning String
- Replace format!() macros with write!() for direct buffer output
- Add const coordinate caching lookup tables for coordinates 0-199
- Pre-compute stroke requirements and per-command buffer estimates
- Add writers module with optimized path generation functions

This eliminates intermediate String allocations during SVG generation.

| Benchmark | Before (µs) | After (µs) | Improvement |
|-----------|-------------|------------|-------------|
| `svg/to_str` | 24.32 | 4.62 | **-81.0%** |
| `svg_shapes/square` | 24.29 | 4.62 | **-81.0%** |
| `svg_shapes/circle` | 25.58 | 4.73 | **-81.5%** |
| `svg_shapes/rounded_square` | 63.08 | 13.22 | **-79.0%** |
| `svg_shapes/vertical` | 24.08 | 4.84 | **-79.9%** |
| `svg_shapes/horizontal` | 24.22 | 4.63 | **-80.9%** |
| `svg_shapes/diamond` | 26.14 | 4.89 | **-81.3%** |
| `svg_versions/V03/square` | 33.26 | 6.09 | **-81.7%** |
| `svg_versions/V03/rounded_square` | 88.56 | 17.78 | **-79.9%** |
| `svg_versions/V10/square` | 121.63 | 22.40 | **-81.6%** |
| `svg_versions/V10/rounded_square` | 317.72 | 67.48 | **-78.8%** |
| `svg_versions/V20/square` | 337.23 | 62.57 | **-81.5%** |
| `svg_versions/V20/rounded_square` | 868.74 | 188.60 | **-78.3%** |
| `svg_versions/V30/square` | 720.80 | 136.67 | **-81.0%** |
| `svg_versions/V30/rounded_square` | 1953.2 | 400.83 | **-79.5%** |
| `svg_versions/V40/square` | 1157.6 | 219.48 | **-81.0%** |
| `svg_versions/V40/rounded_square` | 2998.7 | 639.11 | **-78.7%** |

Timings on my apple m1. 