### PR TITLE
fix(score): mask selection scores columns and honours ISO N3 light-run context

### DIFF
--- a/src/placement.rs
+++ b/src/placement.rs
@@ -94,14 +94,14 @@ pub fn place_on_matrix(
     let mut qr = default::create_matrix(version);
     place_on_matrix_data(&mut qr, structure_as_binarystring);
 
-    let transpose = default::transpose(&qr);
-
     for mask in MASKS {
         let mut copy = qr.clone();
-        let copy_transpose = transpose.clone();
 
         datamasking::mask(&mut copy, mask);
-        let matrix_score = score::score(&copy, &copy_transpose);
+        // Columns must be scored on the *masked* matrix: with a transpose
+        // taken before masking, every vertical penalty was a constant across
+        // masks, so the columns never influenced which mask is chosen.
+        let matrix_score = score::score(&copy);
         if matrix_score < best_score {
             best_score = matrix_score;
             best_mask = mask;

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -10,7 +10,7 @@ use crate::encode::Mode;
 use crate::helpers;
 use crate::{encode, Version, ECL};
 
-const QR_MAX_WIDTH: usize = 177;
+pub(crate) const QR_MAX_WIDTH: usize = 177;
 const QR_MAX_MODULES: usize = QR_MAX_WIDTH * QR_MAX_WIDTH;
 
 /// A `QRCode` can be created using [`QRBuilder`]. Simple API for simple usage.

--- a/src/score.rs
+++ b/src/score.rs
@@ -3,8 +3,6 @@
 
 #![warn(missing_docs)]
 
-#[cfg(test)]
-use crate::default::transpose;
 use crate::module::{Module, ModuleType};
 use crate::QRCode;
 
@@ -27,8 +25,7 @@ pub fn test_matrix_dark_modules(qr: &QRCode) -> u32 {
 
 #[cfg(test)]
 pub fn test_matrix_pattern_and_line(qr: &QRCode) -> (u32, u32, u32) {
-    let transpose = transpose(qr);
-    matrix_pattern_and_line(qr, &transpose)
+    matrix_pattern_and_line(qr)
 }
 
 #[cfg(test)]
@@ -83,7 +80,16 @@ fn matrix_score_squares(qr: &QRCode) -> u32 {
 /// We convert the line to a u11 (supposedly) so comparing it to a pattern is
 /// a simple comparison.
 fn line(line: &[Module]) -> (u32, u32) {
-    const PATTERN_LEN: usize = 7;
+    // ISO/IEC 18004 rule N3: a 1011101 finder lookalike only scores when it is
+    // preceded or followed by four light modules. The rolling window is 11 bits
+    // wide and scans the whole line by value: patterns spanning data and
+    // function modules change with the mask and must be counted. Modules
+    // beyond the symbol edge count as light (the quiet zone), matching the
+    // reference implementations; a lookalike that is light on both sides
+    // matches both windows and scores twice.
+    const PATTERN_LIGHT_BEFORE: u16 = 0b00001011101;
+    const PATTERN_LIGHT_AFTER: u16 = 0b10111010000;
+    const PATTERN_WINDOW: u16 = 0b11111111111;
 
     let mut line_score = 0;
     let mut patt_score = 0;
@@ -91,12 +97,14 @@ fn line(line: &[Module]) -> (u32, u32) {
     let mut count = 1;
     let mut current = !line[0].value();
 
-    let mut buffer = 0;
-    let mut count_data = 0;
+    // Starts at zero: the leading bits stand in for the light quiet zone.
+    let mut buffer: u16 = 0;
 
     for &item in line {
-        buffer = ((buffer << 1) | u16::from(item.value())) & 0b111_1111;
-        count_data += 1;
+        buffer = ((buffer << 1) | u16::from(item.value())) & PATTERN_WINDOW;
+        if buffer == PATTERN_LIGHT_BEFORE || buffer == PATTERN_LIGHT_AFTER {
+            patt_score += 40;
+        }
 
         if item.value() != current {
             if count >= 5 {
@@ -111,13 +119,8 @@ fn line(line: &[Module]) -> (u32, u32) {
                 line_score += count - 2;
             }
 
-            count_data = 0;
             count = 0;
             continue;
-        }
-
-        if count_data >= PATTERN_LEN && buffer == 0b101_1101 {
-            patt_score += 40;
         }
 
         count += 1;
@@ -127,22 +130,42 @@ fn line(line: &[Module]) -> (u32, u32) {
         line_score += count - 2;
     }
 
+    // Shift the trailing quiet zone in; only the lights-after pattern can
+    // still complete here.
+    for _ in 0..4 {
+        buffer = (buffer << 1) & PATTERN_WINDOW;
+        if buffer == PATTERN_LIGHT_AFTER {
+            patt_score += 40;
+        }
+    }
+
     (patt_score, line_score)
 }
 
-/// Converts the matrix to lines & columns and feed it to `score_line`
-fn matrix_pattern_and_line(qr: &QRCode, qr_transpose: &QRCode) -> (u32, u32, u32) {
+/// Converts the matrix to lines & columns and feed it to `score_line`.
+///
+/// Columns are gathered into a small stack buffer instead of materializing a
+/// transposed copy of the matrix: scoring runs once per mask probe, and eight
+/// full transposes would dominate the encoding cost.
+fn matrix_pattern_and_line(qr: &QRCode) -> (u32, u32, u32) {
     let mut line_score = 0;
     let mut col_score = 0;
     let mut patt_score = 0;
 
     let n = qr.size;
+    let mut column = [Module::data(Module::LIGHT); crate::qr::QR_MAX_WIDTH];
 
     for i in 0..n {
         let l = line(&qr[i]);
         line_score += l.1;
 
-        let c = line(&qr_transpose[i]);
+        for (module, &value) in column[..n]
+            .iter_mut()
+            .zip(qr.data[i..n * n].iter().step_by(n))
+        {
+            *module = value;
+        }
+        let c = line(&column[..n]);
         col_score += c.1;
 
         patt_score += l.0 + c.0;
@@ -169,10 +192,10 @@ fn dark_module_score(qr: &QRCode) -> u32 {
 ///   - N - 2 points for each line with N consecutive modules of the same color (N >= 5)
 /// - `matrix_score_squares`: 3 points for each 2x2 square (black or white)
 /// - `dark_module_score`: 10 points for each 5% of dark modules away from 50%
-pub fn score(qr: &QRCode, qr_transpose: &QRCode) -> u32 {
+pub fn score(qr: &QRCode) -> u32 {
     let dark_score = dark_module_score(qr);
     let square_score = matrix_score_squares(qr);
-    let (line_score, col_score, patt_score) = matrix_pattern_and_line(qr, qr_transpose);
+    let (line_score, col_score, patt_score) = matrix_pattern_and_line(qr);
 
     line_score + patt_score + col_score + dark_score + square_score
 }

--- a/src/tests/score.rs
+++ b/src/tests/score.rs
@@ -51,7 +51,7 @@ fn example_com() {
     assert_eq!(dark_score, 0, "dark score, expected 0");
     assert_eq!(square_score, 138, "square score, expected 138");
     assert_eq!(line_score + col_score, 117, "line col score, expected 117");
-    assert_eq!(pattern_score, 240, "pattern score, expected 240");
+    assert_eq!(pattern_score, 880, "pattern score, expected 880");
 }
 
 #[rustfmt::skip]
@@ -98,7 +98,7 @@ fn fast_qr_com() {
     assert_eq!(dark_score, 0, "dark score, expected 0");
     assert_eq!(square_score, 174, "square score, expected 174");
     assert_eq!(line_score + col_score, 108, "line col score, expected 108");
-    assert_eq!(pattern_score, 80, "pattern score, expected 80");
+    assert_eq!(pattern_score, 840, "pattern score, expected 840");
 }
 
 #[rustfmt::skip]
@@ -178,7 +178,7 @@ fn xiaojiba_dev() {
     assert_eq!(dark_score, 0, "dark score, expected 0");
     assert_eq!(square_score, 150, "square score, expected 150");
     assert_eq!(line_score + col_score, 95, "line col score, expected 95");
-    assert_eq!(pattern_score, 160, "pattern score, expected 160");
+    assert_eq!(pattern_score, 720, "pattern score, expected 720");
 }
 
 #[test]
@@ -312,6 +312,7 @@ fn col_by_col_xiaojiba() {
 #[test]
 fn pattern() {
     // Module data: true false true true true false true
+    // The quiet zone counts as light context on both sides: 2 * 40.
     let line = [
         DATA(T),
         DATA(F),
@@ -322,7 +323,7 @@ fn pattern() {
         DATA(T),
     ];
 
-    assert_eq!(test_score_pattern(&line), 40, "pattern, expected 40");
+    assert_eq!(test_score_pattern(&line), 80, "pattern, expected 80");
 
     // Module data: true false true true true false true (double)
     let line = [
@@ -363,7 +364,8 @@ fn pattern() {
 
     assert_eq!(test_score_pattern(&line), 80, "pattern, expected 80");
 
-    // Module data: true false true true true false true (double using middle)
+    // Separator-flanked pattern: the light separator modules plus the quiet
+    // zone give four light modules on both sides: 2 * 40.
     let line = [
         EMPT(F),
         DATA(T),
@@ -376,5 +378,38 @@ fn pattern() {
         EMPT(F),
     ];
 
-    assert_eq!(test_score_pattern(&line), 40, "pattern, expected 40");
+    assert_eq!(test_score_pattern(&line), 80, "pattern, expected 80");
+
+    // Dark modules on both sides: no four-light run before or after, so the
+    // lookalike does not score (ISO/IEC 18004 rule N3).
+    let line = [
+        DATA(T),
+        DATA(T),
+        DATA(F),
+        DATA(T),
+        DATA(T),
+        DATA(T),
+        DATA(F),
+        DATA(T),
+        DATA(T),
+    ];
+
+    assert_eq!(test_score_pattern(&line), 0, "pattern, expected 0");
+}
+#[test]
+fn mask_selection_considers_columns() {
+    // Regression test for the fix of issue #77: when the transpose was taken
+    // from the unmasked matrix, vertical penalties were identical for all
+    // masks and this input selected VerticalLines; with column-aware scoring
+    // it selects Diamonds. Every mask yields a valid symbol either way — this
+    // pins that columns actually influence the choice.
+    let qr = crate::QRBuilder::new("https://fast-qr.com/")
+        .ecl(crate::ECL::H)
+        .build()
+        .unwrap();
+    assert!(
+        matches!(qr.mask, Some(crate::Mask::Diamonds)),
+        "expected Mask::Diamonds, got {:?}",
+        qr.mask
+    );
 }


### PR DESCRIPTION
Fixes #77 — both problems reported there turned out to be real.

  ## What was wrong
  
  1. **The transpose used for column scoring was never masked.** It was built
     once from the unmasked matrix before the mask loop, so every vertical
     penalty was a constant across all 8 probes — columns had no influence on
     which mask got chosen.

  2. **The finder-lookalike test scored every bare `1011101` window.**
     ISO/IEC 18004 rule N3 only scores the pattern when it is preceded or
     followed by four light modules.

  ## What this PR does

  - `placement.rs`: drop the transposed copy entirely. Columns are gathered                                                                                                                                  
    per probe from the *masked* candidate into a small stack buffer inside
    `score.rs` (`[Module; 177]`, strided reads via `step_by`).
  - `score.rs`: scan each line with an 11-bit rolling window over module
    *values* across the whole line — patterns spanning data and function
    modules change with the mask, so they must count. Modules beyond the
    symbol edge count as light (the quiet zone), and a lookalike that is
    light on both sides scores twice; both choices match the reference
    implementations (kennytm/qrcode-rust treats out-of-bounds as light,
    nayuki/QR-Code-generator counts both sides separately).

  ## Impact

  Every mask yields a valid symbol, so no previously generated code was                                                                                                                                      
  broken — selection just sometimes settled on a second-best mask. Of five
  sample inputs, one changes its chosen mask (`https://fast-qr.com/` at
  ECL H: VerticalLines → Diamonds); the rest are unchanged.

  ## Benchmarks

  criterion, the repo's own `benches/qr.rs` (200 samples, 10 s measurement,                                                                                                                                  
  `https://example.com/`, ECL H), fast_qr side only, vs. current master:

  | bench | master | this PR | Δ mean |
  |---|---|---|---|
  | V03H | 34.92 µs | 32.77 µs | **−6.2 %** |
  | V10H | 116.56 µs | 123.52 µs | +6.0 % |
  | V40H | 1.1930 ms | 1.2695 ms | +6.4 % |

  Small versions get *faster*: dropping the up-front transpose and its eight
  per-probe clones outweighs the column gather. Larger versions pay ~6 % for
  genuinely scoring columns per probe. A naive fix (transpose each masked
  candidate) costs +21–28 % and was rejected; a fused single-sweep scorer
  was measured at +54–137 % (per-module state round-trips through memory)
  and rejected too.

  ## Tests
  
  - Matrix golden pattern scores recomputed and cross-checked against an
    independent implementation of rule N3 (they now include the constant
    contribution of the finder patterns themselves, which shifts all masks
    equally).
  - Line-level expectations updated; new case for a lookalike with dark
    context on both sides (scores 0).
  - New regression test pinning that columns influence the selection.

  All 175 unit tests pass; clippy and fmt are clean.
