### PR TITLE
fix: resolve function pointer comparison lints from recent Rust version

### DIFF
--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -54,7 +54,7 @@ pub enum Shape {
 
 /// Different possible Shapes to represent modules in a [`crate::QRCode`]
 #[cfg(not(feature = "wasm-bindgen"))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy)]
 pub enum Shape {
     /// Square Shape
     Square,
@@ -91,6 +91,42 @@ pub enum Shape {
     ///         fill="#000000" />
     /// </svg>
     Command(ModuleFunction),
+}
+
+// Manual implementations instead of derives: deriving them would compare the
+// `ModuleFunction` pointers in `Shape::Command` directly, which triggers the
+// `unpredictable_function_pointer_comparisons` lint (Rust 1.85+). Comparing
+// the addresses through `usize` keeps the previous behaviour and makes the
+// address comparison explicit (same-address functions compare equal, with the
+// usual caveat that function addresses are not guaranteed to be unique).
+#[cfg(not(feature = "wasm-bindgen"))]
+impl PartialEq for Shape {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Command(a), Self::Command(b)) => *a as usize == *b as usize,
+            _ => usize::from(*self) == usize::from(*other),
+        }
+    }
+}
+
+#[cfg(not(feature = "wasm-bindgen"))]
+impl Eq for Shape {}
+
+#[cfg(not(feature = "wasm-bindgen"))]
+impl PartialOrd for Shape {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(not(feature = "wasm-bindgen"))]
+impl Ord for Shape {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        match (self, other) {
+            (Self::Command(a), Self::Command(b)) => (*a as usize).cmp(&(*b as usize)),
+            _ => usize::from(*self).cmp(&usize::from(*other)),
+        }
+    }
 }
 
 impl From<Shape> for usize {

--- a/src/convert/svg.rs
+++ b/src/convert/svg.rs
@@ -291,7 +291,7 @@ impl SvgBuilder {
             let command_color = command_colors[i].as_ref().unwrap_or(&self.dot_color);
             // Allows to compare if two function pointers are the same
             // This works because there is no notion of Generics for `rounded_square`
-            if command as usize == Shape::rounded_square as usize {
+            if command as usize == Shape::rounded_square as ModuleFunction as usize {
                 paths[i].push_str(&format!(
                     r##"" stroke-width=".3" stroke-linejoin="round" stroke="{}"##,
                     command_color.to_str()


### PR DESCRIPTION
CI (`RUSTFLAGS: --deny warnings`) currently fails on `master` with recent stable Rust, independent of any open PR:

  - `unpredictable_function_pointer_comparisons`: 
  the derived `PartialEq`/`Ord` on `Shape` compare the `ModuleFunction` pointer inside `Shape::Command`.
  
- `function_casts_as_integer`: 
  `Shape::rounded_square as usize` in `svg.rs` casts a function item directly to an integer.

  This fixes both without `#[allow]`:

  - Manual `PartialEq`/`Eq`/`PartialOrd`/`Ord` impls for `Shape` that compare `Command` by function address via `usize`:
  same behaviour as the derives, but the address comparison is explicit.
  (`std::ptr::fn_addr_eq` would be the idiomatic choice, but it is only stable since 1.85 and the crate's MSRV is 1.59.)
  - An explicit fn-pointer coercion (`as ModuleFunction`) before the `rounded_square` cast.

  All CI build combinations (incl. wasm targets and benches) and the test suite pass locally under `--deny warnings`.

Longer term it might be worth considering whether `Shape` should implement the comparison traits at all equality over arbitrary function pointers can't be made reliable (the same function can have different addresses across codegen units). Dropping them (or keeping `Shape` symbolic until render time instead of deref-ing to fn pointers, cf. the pointer probe in `svg.rs`) would be a candidate for the next breaking release. This PR deliberately keeps behavior unchanged.
